### PR TITLE
Several Xcode fixes that prevented the extension from building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 dist.pem
 dist.crx
 ts-playground-links.crx
+xcuserdata

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "github-codeblocks-typescript",
+  "version": "1.0.0",
+  "description": "Adds a link to the TS playground on TypeScript codeblocks in GitHub ",
+  "main": "index.js",
+  "scripts": {
+    "watch": "webpack --config webpack/webpack.dev.js --watch",
+    "build": "webpack --config webpack/webpack.prod.js",
+    "clean": "rimraf dist"
+  },
+  "author": "Orta Therox",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/orta/ts-playgrounds-github.git"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/chrome": "~0.0.83",
+    "@types/jquery": "~3.3.29",
+    "copy-webpack-plugin": "^5.0.3",
+    "rimraf": "^2.6.3",
+    "ts-loader": "~5.4.3",
+    "typescript": "~3.4.5",
+    "webpack": "~4.17.2",
+    "webpack-cli": "~3.1.0",
+    "webpack-merge": "~4.1.4"
+  }
+}

--- a/safari/TS Playgrounds/TS Playgrounds.xcodeproj/project.pbxproj
+++ b/safari/TS Playgrounds/TS Playgrounds.xcodeproj/project.pbxproj
@@ -67,8 +67,8 @@
 		608450B622EF1DCF00802CE3 /* ToolbarItemIcon.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = ToolbarItemIcon.pdf; sourceTree = "<group>"; };
 		608450B822EF1DCF00802CE3 /* TS_Playgrounds_Safari.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TS_Playgrounds_Safari.entitlements; sourceTree = "<group>"; };
 		608450C022EF1E6200802CE3 /* add-ts-playground-links.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = "add-ts-playground-links.js"; path = "../../../dist/js/add-ts-playground-links.js"; sourceTree = "<group>"; };
-		60C7997322EF203800B18E98 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ViewController.h; path = "../../../../../../../../System/Volumes/Data/Users/orta/dev/typescript/ts-playgrounds-github/safari/TS Playgrounds/TS Playgrounds/ViewController.h"; sourceTree = "<group>"; };
-		60C7997422EF203800B18E98 /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = ViewController.m; path = "../../../../../../../../System/Volumes/Data/Users/orta/dev/typescript/ts-playgrounds-github/safari/TS Playgrounds/TS Playgrounds/ViewController.m"; sourceTree = "<group>"; };
+		60C7997322EF203800B18E98 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		60C7997422EF203800B18E98 /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */


### PR DESCRIPTION
* Restore `package.json` from the most recent commit that had it. I couldn't get Yarn to build without it so I guessed it should be present.
* Fix incorrect pathnames in the project file. It had a weird file reference instead of a plain relative file ref. PBX must be destroyed.
* Add `xcuserdata` to `.gitignore`. Each user's data has a different directory.