### PR TITLE
Adds mutation observer to link new blocks when they are created

### DIFF
--- a/src/add-ts-playground-links.ts
+++ b/src/add-ts-playground-links.ts
@@ -47,7 +47,7 @@ const addLinkToFile = (allMainBlocks: HTMLCollectionOf<Element>) => {
   }
 };
 
-const addLinkToCodeblocksInMarkdown = (allCodeBlocks: HTMLCollectionOf<Element>) => {
+const addLinkToCodeblocks = (allCodeBlocks: HTMLCollectionOf<Element>) => {
   for (const block of allCodeBlocks) {
     // @ts-ignore
     // This exists for sure at runtime
@@ -58,14 +58,30 @@ const addLinkToCodeblocksInMarkdown = (allCodeBlocks: HTMLCollectionOf<Element>)
   }
 };
 
+const observer =
+  new MutationObserver((mutations: MutationRecord[]) => {
+    addLinkToCodeblocksInMarkdown()
+  });
+
+const addLinkToCodeblocksInMarkdown = () => {
+  const allInlineCodeBlocks = document.getElementsByClassName("highlight-source-ts");
+  if (allInlineCodeBlocks.length) {
+    addLinkToCodeblocks(allInlineCodeBlocks);
+  }
+}
+
 setTimeout(() => {
   const mainTSFiles = document.getElementsByClassName("type-typescript");
   if (mainTSFiles.length) {
     addLinkToFile(mainTSFiles);
   }
 
-  const allInlineCodeBlocks = document.getElementsByClassName("highlight-source-ts");
-  if (allInlineCodeBlocks.length) {
-    addLinkToCodeblocksInMarkdown(allInlineCodeBlocks);
-  }
+  addLinkToCodeblocksInMarkdown();
+
+  // This will be triggered every time a new comment is added, allowing us
+  // to link new TypeScript blocks as they are created.
+  observer.observe(document.getElementsByClassName("js-discussion")[0] as Node, {
+    attributes: false,
+    childList: true,
+  });
 }, 300);

--- a/src/add-ts-playground-links.ts
+++ b/src/add-ts-playground-links.ts
@@ -39,7 +39,6 @@ const addLinkToFile = (allMainBlocks: HTMLCollectionOf<Element>) => {
       fetch(newPath)
         .then(res => res.text())
         .then(text => {
-          //   debugger
           window.location.href = "https://www.typescriptlang.org/play/#src=" + encodeURI(text);
         });
     });
@@ -68,7 +67,20 @@ const addLinkToCodeblocksInMarkdown = () => {
   if (allInlineCodeBlocks.length) {
     addLinkToCodeblocks(allInlineCodeBlocks);
   }
-}
+};
+
+const listenToNewComments = () => {
+  const commentsContainer = document.getElementsByClassName("js-discussion")[0];
+
+  if (commentsContainer) {
+    // This will be triggered every time a new comment is added, allowing us
+    // to link new TypeScript blocks as they are created.
+    observer.observe(commentsContainer as Node, {
+      attributes: false,
+      childList: true,
+    });
+  }
+};
 
 setTimeout(() => {
   const mainTSFiles = document.getElementsByClassName("type-typescript");
@@ -77,11 +89,5 @@ setTimeout(() => {
   }
 
   addLinkToCodeblocksInMarkdown();
-
-  // This will be triggered every time a new comment is added, allowing us
-  // to link new TypeScript blocks as they are created.
-  observer.observe(document.getElementsByClassName("js-discussion")[0] as Node, {
-    attributes: false,
-    childList: true,
-  });
+  listenToNewComments();
 }, 300);


### PR DESCRIPTION
Links were only being added when the page loaded, so new comments with `typescript` blocks wouldn't be linked until the page refreshed. This pr fixes it 😄 

## Before

![before](https://user-images.githubusercontent.com/1916041/63774287-51e25780-c8b3-11e9-841b-24fb6ab39c15.gif)

## After

![after](https://user-images.githubusercontent.com/1916041/63774298-59096580-c8b3-11e9-85b7-adaf626fc9e7.gif)